### PR TITLE
use Oozie delegation token, if provided

### DIFF
--- a/slider-core/src/main/java/org/apache/slider/client/SliderClient.java
+++ b/slider-core/src/main/java/org/apache/slider/client/SliderClient.java
@@ -584,6 +584,11 @@ public class SliderClient extends AbstractSliderLaunchedService implements RunSe
     
     AggregateConf instanceDefinition = new AggregateConf();
     ConfTreeOperations appConf = instanceDefinition.getAppConfOperations();
+
+    String tokenCredentials = conf.get("mapreduce.job.credentials.binary");
+    if (tokenCredentials != null)
+      appConf.set("mapreduce.job.credentials.binary", tokenCredentials);
+
     ConfTreeOperations resources = instanceDefinition.getResourceOperations();
     ConfTreeOperations internal = instanceDefinition.getInternalOperations();
     //initial definition is set by the providers 

--- a/slider-core/src/main/java/org/apache/slider/core/launch/AbstractLauncher.java
+++ b/slider-core/src/main/java/org/apache/slider/core/launch/AbstractLauncher.java
@@ -171,7 +171,15 @@ public abstract class AbstractLauncher extends Configured {
 
 
     DataOutputBuffer dob = new DataOutputBuffer();
-    credentials.writeTokenStorageToStream(dob);
+    if (this.getConf().get("mapreduce.job.credentials.binary") != null) {
+      // use delegation tokens, i.e. from Oozie
+      Credentials creds = UserGroupInformation.getLoginUser().getCredentials();
+      creds.writeTokenStorageToStream(dob);
+    } else {
+      // normal auth
+      credentials.writeTokenStorageToStream(dob);
+    }
+
     ByteBuffer tokenBuffer = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
     containerLaunchContext.setTokens(tokenBuffer);
 

--- a/slider-core/src/main/java/org/apache/slider/core/launch/AppMasterLauncher.java
+++ b/slider-core/src/main/java/org/apache/slider/core/launch/AppMasterLauncher.java
@@ -204,9 +204,11 @@ public class AppMasterLauncher extends AbstractLauncher {
       );
     }
 
-    // For now, only getting tokens for the default file-system.
-    FileSystem fs = coreFileSystem.getFileSystem();
-    fs.addDelegationTokens(tokenRenewer, credentials);
+    if (this.getConf().get("mapreduce.job.credentials.binary") == null) {
+      // For now, only getting tokens for the default file-system.
+      FileSystem fs = coreFileSystem.getFileSystem();
+      fs.addDelegationTokens(tokenRenewer, credentials);
+    }
   }
 
  


### PR DESCRIPTION
The oozie shell-action script which invokes "slider create" must dynamically create a token.conf file, as follows:

echo "&lt;configuration&gt;&lt;property&gt;&lt;name&gt;mapreduce.job.credentials.binary&lt;/name&gt;&lt;value&gt;${HADOOP_TOKEN_FILE_LOCATION}&lt;/value&gt;&lt;/property&gt;&lt;/configuration&gt;" &gt; token.conf

Then, the script invokes "slider create -conf token.conf" with the included changes.
